### PR TITLE
Rebase theme overrides and improve image optimisation

### DIFF
--- a/.github/percy.yml
+++ b/.github/percy.yml
@@ -10,3 +10,5 @@ snapshot:
 static:
   include:
     - /(posts|categories|series|about|contact|projects)/**/*.html
+  exclude:
+    - /**/page/1/index.html

--- a/.github/percy.yml
+++ b/.github/percy.yml
@@ -8,8 +8,25 @@ snapshot:
     - 1920
   minHeight: 1024
   enableJavaScript: true
-  percyCSS: |
-    img[loading="lazy"] { content-visibility: visible !important; }
+  discovery:
+    networkIdleTimeout: 750
+  execute:
+    beforeSnapshot: |
+      const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+      
+      // Force all lazy images to load eagerly and scroll them into view
+      for (const img of document.querySelectorAll('img[loading="lazy"]')) {
+        img.loading = 'eager';
+        img.scrollIntoView();
+        await sleep(100);
+      }
+      
+      // Scroll up and down to ensure all lazy loads are triggered
+      window.scrollTo(0, 0);
+      await sleep(500);
+      window.scrollTo(0, document.body.scrollHeight);
+      await sleep(500);
+      window.scrollTo(0, 0);
 static:
   include:
     - /(posts|categories|series|about|contact|projects)/**/*.html

--- a/.github/percy.yml
+++ b/.github/percy.yml
@@ -8,27 +8,18 @@ snapshot:
     - 1920
   minHeight: 1024
   enableJavaScript: true
-  discovery:
-    networkIdleTimeout: 750
-  execute:
-    beforeSnapshot: |
-      const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
-      
-      // Force all lazy images to load eagerly and scroll them into view
-      for (const img of document.querySelectorAll('img[loading="lazy"]')) {
-        img.loading = 'eager';
-        img.scrollIntoView();
-        await sleep(100);
-      }
-      
-      // Scroll up and down to ensure all lazy loads are triggered
-      window.scrollTo(0, 0);
-      await sleep(500);
-      window.scrollTo(0, document.body.scrollHeight);
-      await sleep(500);
-      window.scrollTo(0, 0);
 static:
   include:
     - /(posts|categories|series|about|contact|projects)/**/*.html
   exclude:
     - /**/page/1/index.html
+  options:
+    - files: "/posts/**/*.html"
+      execute: |
+        // Force all lazy images to load eagerly
+        document.querySelectorAll('img[loading="lazy"]').forEach(img => {
+          img.loading = 'eager';
+        });
+        // Scroll to trigger lazy load
+        window.scrollTo(0, 0);
+        window.scrollTo(0, document.body.scrollHeight);

--- a/.github/percy.yml
+++ b/.github/percy.yml
@@ -7,6 +7,9 @@ snapshot:
     - 375
     - 1920
   minHeight: 1024
+  enableJavaScript: true
+  percyCSS: |
+    img[loading="lazy"] { content-visibility: visible !important; }
 static:
   include:
     - /(posts|categories|series|about|contact|projects)/**/*.html

--- a/.github/percy.yml
+++ b/.github/percy.yml
@@ -13,13 +13,5 @@ static:
     - /(posts|categories|series|about|contact|projects)/**/*.html
   exclude:
     - /**/page/1/index.html
-  options:
-    - files: "/posts/**/*.html"
-      execute: |
-        // Force all lazy images to load eagerly
-        document.querySelectorAll('img[loading="lazy"]').forEach(img => {
-          img.loading = 'eager';
-        });
-        // Scroll to trigger lazy load
-        window.scrollTo(0, 0);
-        window.scrollTo(0, document.body.scrollHeight);
+discovery:
+  capture-srcset: true

--- a/.github/percy/percy.yml
+++ b/.github/percy/percy.yml
@@ -8,10 +8,10 @@ snapshot:
     - 1920
   minHeight: 1024
   enableJavaScript: true
-static:
-  include:
-    - /(posts|categories|series|about|contact|projects)/**/*.html
-  exclude:
-    - /**/page/1/index.html
+# static:
+#   include:
+#     - /(posts|categories|series|about|contact|projects)/**/*.html
+#   exclude:
+#     - /**/page/1/index.html
 discovery:
   capture-srcset: true

--- a/.github/percy/snapshots.js
+++ b/.github/percy/snapshots.js
@@ -45,6 +45,9 @@ module.exports = async () => {
     });
   });
 
+  // Allow process to exit even if server is still running
+  server.unref();
+
   // Get all HTML files matching the pattern
   const files = glob.sync('public/{posts,categories,series,about,contact,projects}/**/*.html', {
     ignore: '**/page/1/index.html'

--- a/.github/percy/snapshots.js
+++ b/.github/percy/snapshots.js
@@ -1,0 +1,77 @@
+const glob = require('glob');
+const path = require('path');
+const http = require('http');
+const fs = require('fs');
+
+const PORT = 5338;
+
+// Simple static file server
+const server = http.createServer((req, response) => {
+  const filePath = path.join(__dirname, '../../public', req.url === '/' ? 'index.html' : req.url);
+  
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      response.writeHead(404);
+      response.end('Not found');
+      return;
+    }
+    
+    const ext = path.extname(filePath);
+    const contentType = {
+      '.html': 'text/html',
+      '.css': 'text/css',
+      '.js': 'application/javascript',
+      '.json': 'application/json',
+      '.png': 'image/png',
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.webp': 'image/webp',
+      '.svg': 'image/svg+xml',
+      '.woff': 'font/woff',
+      '.woff2': 'font/woff2'
+    }[ext] || 'application/octet-stream';
+    
+    response.writeHead(200, { 'Content-Type': contentType });
+    response.end(data);
+  });
+});
+
+module.exports = async () => {
+  // Start server
+  await new Promise((resolve) => {
+    server.listen(PORT, () => {
+      console.log(`Serving public directory at http://localhost:${PORT}`);
+      resolve();
+    });
+  });
+
+  // Get all HTML files matching the pattern
+  const files = glob.sync('public/{posts,categories,series,about,contact,projects}/**/*.html', {
+    ignore: '**/page/1/index.html'
+  });
+
+  return files.map(file => {
+    const relativePath = path.relative('public', file);
+    const name = relativePath.replace(/\.html$/, '');
+    
+    const snapshot = {
+      name,
+      url: `http://localhost:${PORT}/${relativePath}`
+    };
+
+    // Only add execute for posts
+    if (file.includes('/posts/')) {
+      snapshot.execute = function() {
+        // Force all lazy images to load eagerly
+        document.querySelectorAll('img[loading="lazy"]').forEach(img => {
+          img.loading = 'eager';
+        });
+        // Scroll to trigger lazy load
+        window.scrollTo(0, document.body.scrollHeight);
+        window.scrollTo(0, 0);
+      };
+    }
+
+    return snapshot;
+  });
+};

--- a/.github/percy/snapshots.js
+++ b/.github/percy/snapshots.js
@@ -8,14 +8,14 @@ const PORT = 5338;
 // Simple static file server
 const server = http.createServer((req, response) => {
   const filePath = path.join(__dirname, '../../public', req.url === '/' ? 'index.html' : req.url);
-  
+
   fs.readFile(filePath, (err, data) => {
     if (err) {
       response.writeHead(404);
       response.end('Not found');
       return;
     }
-    
+
     const ext = path.extname(filePath);
     const contentType = {
       '.html': 'text/html',
@@ -30,7 +30,7 @@ const server = http.createServer((req, response) => {
       '.woff': 'font/woff',
       '.woff2': 'font/woff2'
     }[ext] || 'application/octet-stream';
-    
+
     response.writeHead(200, { 'Content-Type': contentType });
     response.end(data);
   });
@@ -55,8 +55,9 @@ module.exports = async () => {
 
   return files.map(file => {
     const relativePath = path.relative('public', file);
-    const name = relativePath.replace(/\.html$/, '');
-    
+    // Use the full path with leading slash to match static directory snapshot names
+    const name = `/${relativePath}`;
+
     const snapshot = {
       name,
       url: `http://localhost:${PORT}/${relativePath}`

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -115,7 +115,7 @@ jobs:
           arguments: >-
             --checks Links,Images,Scripts,Favicon,OpenGraph
             --ignore_missing_alt
-            --ignore_status_codes 403
+            --ignore_status_codes 403,429
             --typhoeus='{"headers":{"User-Agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:134.0) Gecko/20100101 Firefox/134.0"}}'
             --cache='{"timeframe": {"external": "30d"}}'
             --swap_urls 'https\:\/\/blog.tiga.tech/:/'

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -104,7 +104,7 @@ jobs:
           mkdir $HUGO_PUBLISHDIR
           tar xvf artifact.tar -C $HUGO_PUBLISHDIR
 
-      - run: npx percy snapshot -c .github/percy.yml ${{ env.HUGO_PUBLISHDIR }}
+      - run: npx percy snapshot -c .github/percy/percy.yml .github/percy/snapshots.js
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           PERCY_POSTINSTALL_BROWSER: true

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           node-version: '14'
 
-      - run: npm install --save-dev @percy/cli
+      - run: npm install @percy/cli
 
       - uses: actions/download-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,112 @@ This can be disabled per-page with by setting the `hideFeatureWatermark` page pa
 | `{{< gallery >}} ... {{< /gallery >}}`                                                     | [Blowfish gallery shortcode](https://blowfish.page/docs/shortcodes/#gallery), images are processed based on method used to add include them.<br>See rows above for image inclusion methods. |
 | `{{< gallery_glob images="path-glob" class="image classes" caption="optional caption" >}}` | Builds a gallery from a glob pattern.<br>Passes images through `img` shortcode and inheriting its features. |
 
+### Image Processing Pipeline
+
+> [!IMPORTANT]
+> There may be some inaccuracies, this diagram was AI-generated.
+
+```mermaid
+graph TD
+    subgraph "Image Entry Points"
+        A1["Markdown Image<br/>![alt](path)"]
+        A2["img Shortcode<br/>{{< img >}}"]
+        A3["gallery_glob Shortcode<br/>{{< gallery_glob >}}"]
+        A4["Article List<br/>Featured Images"]
+    end
+
+    subgraph "Render Layer"
+        B1["render-image.html<br/>(Markdown processor)"]
+        B2["shortcodes/img.html"]
+        B3["shortcodes/gallery_glob.html"]
+        B4["article-link/simple.html<br/>(Theme partial)"]
+    end
+
+    subgraph "Processing Layer"
+        C1["partials/img.html<br/>(Main image partial)"]
+        C2["partials/process_list_featured_img.html<br/>(List thumbnails)"]
+    end
+
+    subgraph "Watermarking Layer"
+        D1["partials/watermark.html<br/>(Full images)"]
+        D2["Watermark in<br/>process_list_featured_img"]
+    end
+
+    subgraph "Hugo Image Processing"
+        E1["images.Filter<br/>(AutoOrient)"]
+        E2[".Resize<br/>(600x webp for lists)"]
+        E3[".Process<br/>(webp conversion)"]
+        E4["Logo Resize<br/>(25% height, max 150px)"]
+        E5["images.Overlay<br/>(Apply watermark)"]
+    end
+
+    subgraph "Cache Layer"
+        F1["Site.Store<br/>(Global logo cache)"]
+        F2["Hugo Resource Cache<br/>(resources/_gen/)"]
+    end
+
+    subgraph "Output"
+        G1["HTML img tag<br/>with watermarked image"]
+        G2["CSS background-image<br/>(for list thumbnails)"]
+    end
+
+    %% Entry point routing
+    A1 --> B1
+    A2 --> B2
+    A3 --> B3
+    A4 --> B4
+
+    %% Render layer decisions
+    B1 -->|"Remote URL"| D1
+    B1 -->|"Local image"| C1
+    B2 -->|"caption.markdownify"| C1
+    B3 -->|"Loop images"| C1
+    B4 -->|"Get featured image"| C2
+
+    %% Processing layer
+    C1 -->|"SVG or disabled"| G1
+    C1 -->|"watermark=true"| D1
+    C1 -->|"Process"| E1
+    C2 -->|"Resize + convert"| E2
+    C2 -->|"Should watermark"| D2
+
+    %% Watermarking operations
+    D1 --> F1
+    D2 --> F1
+    F1 -->|"Get cached logo"| E4
+    E4 --> E5
+    D1 --> E5
+    D2 --> E5
+
+    %% Hugo processing
+    E1 --> E3
+    E2 --> E5
+    E3 --> F2
+    E5 --> F2
+
+    %% Output
+    F2 -->|"img partial"| G1
+    F2 -->|"process_list partial"| G2
+
+    %% Styling
+    classDef entryPoint fill:#1e3a5f,stroke:#4a90e2,stroke-width:2px,color:#fff
+    classDef render fill:#3d2817,stroke:#d4a574,stroke-width:2px,color:#fff
+    classDef process fill:#2d1b3d,stroke:#9b59b6,stroke-width:2px,color:#fff
+    classDef watermark fill:#3d1a2b,stroke:#e91e63,stroke-width:2px,color:#fff
+    classDef hugo fill:#1b3d1b,stroke:#66bb6a,stroke-width:2px,color:#fff
+    classDef cache fill:#3d3617,stroke:#fdd835,stroke-width:2px,color:#fff
+    classDef output fill:#1a3d3a,stroke:#26a69a,stroke-width:2px,color:#fff
+
+
+    class A1,A2,A3,A4 entryPoint
+    class B1,B2,B3,B4 render
+    class C1,C2 process
+    class D1,D2 watermark
+    class E1,E2,E3,E4,E5 hugo
+    class F1,F2 cache
+    class G1,G2 output
+```
+
 ## Personal Notes
 
 * [Blowfish built-in shortcodes](https://blowfish.page/docs/shortcodes/).

--- a/README.md
+++ b/README.md
@@ -102,96 +102,91 @@ graph TD
         A4["Article List<br/>Featured Images"]
     end
 
-    subgraph "Render Layer"
+    subgraph "Render/Processing Layer"
         B1["render-image.html<br/>(Markdown processor)"]
+        B1a["RenderImageSimple<br/>(template in render-image.html)"]
+        B1b["RenderImageResponsive<br/>(template in render-image.html)"]
         B2["shortcodes/img.html"]
         B3["shortcodes/gallery_glob.html"]
-        B4["article-link/simple.html<br/>(Theme partial)"]
+        B4["article-link/simple.html"]
+        C1["partials/img.html"]
+        C2["partials/process_list_featured_img.html"]
     end
 
-    subgraph "Processing Layer"
-        C1["partials/img.html<br/>(Main image partial)"]
-        C2["partials/process_list_featured_img.html<br/>(List thumbnails)"]
-    end
-
-    subgraph "Watermarking Layer"
-        D1["partials/watermark.html<br/>(Full images)"]
-        D2["Watermark in<br/>process_list_featured_img"]
+    subgraph "Watermarking"
+        D1["partials/watermark.html"]
     end
 
     subgraph "Hugo Image Processing"
-        E1["images.Filter<br/>(AutoOrient)"]
-        E2[".Resize<br/>(600x webp for lists)"]
-        E3[".Process<br/>(webp conversion)"]
-        E4["Logo Resize<br/>(25% height, max 150px)"]
-        E5["images.Overlay<br/>(Apply watermark)"]
+        E1["AutoOrient filter<br/>(in img.html)"]
+        E2["Resize operation<br/>(in render-image.html)"]
+        E3["Resize for srcset<br/>(in img.html)"]
+        E4["Resize operation<br/>(in process_list)"]
+        E5["WebP conversion<br/>(in img.html)"]
     end
 
-    subgraph "Cache Layer"
-        F1["Site.Store<br/>(Global logo cache)"]
-        F2["Hugo Resource Cache<br/>(resources/_gen/)"]
+    subgraph "Cache/Output"
+        F1["Hugo Resource Cache"]
+        G1["HTML img tag with srcset"]
     end
 
-    subgraph "Output"
-        G1["HTML img tag<br/>with watermarked image"]
-        G2["CSS background-image<br/>(for list thumbnails)"]
-    end
-
-    %% Entry point routing
+    %% Entry points
     A1 --> B1
     A2 --> B2
     A3 --> B3
     A4 --> B4
 
-    %% Render layer decisions
-    B1 -->|"Remote URL"| D1
-    B1 -->|"Local image"| C1
-    B2 -->|"caption.markdownify"| C1
+    %% Markdown path (render-image.html)
+    B1 -->|"Resource not found"| G1
+    B1 -->|"Remote or SVG or<br/>optimization disabled"| B1a
+    B1 -->|"Local resource +<br/>optimization enabled"| B1b
+    
+    B1a -->|"watermark=false"| G1
+    B1a -->|"watermark=true"| D1
+    D1 -->|"Watermarked image<br/>(no srcset)"| G1
+    
+    B1b -->|"Resize to 800x/1280x"| E2
+    E2 -->|"watermark=true"| D1
+    E2 -->|"watermark=false"| F1
+    D1 -->|"Watermarks all 3 sizes<br/>(800x, 1280x, original)"| F1
+
+    %% img shortcode path
+    B2 --> C1
+    
+    %% gallery_glob path
     B3 -->|"Loop images"| C1
-    B4 -->|"Get featured image"| C2
 
-    %% Processing layer
-    C1 -->|"SVG or disabled"| G1
-    C1 -->|"watermark=true"| D1
-    C1 -->|"Process"| E1
-    C2 -->|"Resize + convert"| E2
-    C2 -->|"Should watermark"| D2
+    %% img.html path
+    C1 -->|"SVG/disabled"| G1
+    C1 -->|"Get resource + AutoOrient"| E1
+    E1 -->|"watermark=true"| D1
+    E1 -->|"watermark=false"| E5
+    D1 -->|"Watermarked original"| E5
+    E5 -->|"Convert to WebP"| E3
+    E3 -->|"Create srcset sizes"| F1
 
-    %% Watermarking operations
-    D1 --> F1
-    D2 --> F1
-    F1 -->|"Get cached logo"| E4
-    E4 --> E5
-    D1 --> E5
-    D2 --> E5
-
-    %% Hugo processing
-    E1 --> E3
-    E2 --> E5
-    E3 --> F2
-    E5 --> F2
+    %% Article list path
+    B4 --> C2
+    C2 -->|"Resize first"| E4
+    E4 -->|"600x webp"| D1
+    E4 -->|"watermark=false"| F1
+    D1 -->|"Watermarked thumb"| F1
 
     %% Output
-    F2 -->|"img partial"| G1
-    F2 -->|"process_list partial"| G2
+    F1 --> G1
 
     %% Styling
     classDef entryPoint fill:#1e3a5f,stroke:#4a90e2,stroke-width:2px,color:#fff
     classDef render fill:#3d2817,stroke:#d4a574,stroke-width:2px,color:#fff
-    classDef process fill:#2d1b3d,stroke:#9b59b6,stroke-width:2px,color:#fff
     classDef watermark fill:#3d1a2b,stroke:#e91e63,stroke-width:2px,color:#fff
     classDef hugo fill:#1b3d1b,stroke:#66bb6a,stroke-width:2px,color:#fff
-    classDef cache fill:#3d3617,stroke:#fdd835,stroke-width:2px,color:#fff
-    classDef output fill:#1a3d3a,stroke:#26a69a,stroke-width:2px,color:#fff
-
+    classDef cache fill:#1a3d3a,stroke:#26a69a,stroke-width:2px,color:#fff
 
     class A1,A2,A3,A4 entryPoint
-    class B1,B2,B3,B4 render
-    class C1,C2 process
-    class D1,D2 watermark
+    class B1,B1a,B1b,B2,B3,B4,C1,C2 render
+    class D1 watermark
     class E1,E2,E3,E4,E5 hugo
-    class F1,F2 cache
-    class G1,G2 output
+    class F1,G1 cache
 ```
 
 ## Personal Notes

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,39 +1,146 @@
-<!--
-  Heavily modified version of Blowfish's layouts/_default/_markup/render-image.html.
+{{/*
+  Heavily modified version of Blowfish v2.93.0's layouts/_default/_markup/render-image.html.
   Purpose of modifications is to support custom watermark partial.
-  Much of the original functionality from Blowfish's render-image.html has been split out to the img partial.
--->
+  Integrates watermark support with upstream's responsive image handling.
+*/}}
 
-{{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
-{{ $url := urls.Parse .Destination }}
-{{ $altText := .Text }}
-{{ $caption := .Title }}
+{{- define "RenderImageSimple" -}}
+  {{- $imgObj := .imgObj -}}
+  {{- $src := .src -}}
+  {{- $alt := .alt -}}
+  {{- $watermark := .watermark -}}
+  {{- $watermarkedImg := $imgObj -}}
 
-{{ $watermark := true }}
+  {{- if and $watermark $imgObj -}}
+    {{- $watermarkedImg = partial "watermark" (dict "image" $imgObj "onlyImage" true) -}}
+    {{- $src = $watermarkedImg.RelPermalink -}}
+  {{- end -}}
 
-{{ $class := "my-0 rounded-md"}}
+  <img
+    class="my-0 rounded-md"
+    loading="lazy"
+    decoding="async"
+    fetchpriority="low"
+    alt="{{ $alt }}"
+    src="{{ $src }}"
+    {{ with $watermarkedImg -}}
+      {{ with $watermarkedImg.Width }}width="{{ . }}"{{ end }}
+      {{ with $watermarkedImg.Height }}height="{{ . }}"{{ end }}
+    {{- end }}>
+{{- end -}}
 
-{{ if eq (substr $altText -5 5) "no-wm" }}
-{{ $altText = (trim (replace $altText "no-wm" "") " ") }}
-{{ $watermark = false }}
-{{ end }}
+{{- define "RenderImageResponsive" -}}
+  {{/* Responsive Image
+    The current setting sizes="(min-width: 768px) 50vw, 65vw" makes the iPhone 16 and 16 Pro
+    select a smaller image, while the iPhone 16 Pro Max selects a larger image.
 
-{{ if findRE "^https?" $url.Scheme }}
-  {{ $wmImg := partial "watermark" (dict "image" $url.String "onlyImage" true) }}
-  <figure>
-    <img class={{ $class }} loading="lazy" src="{{ $wmImg.RelPermalink }}" alt="{{ $altText }}" />
-    {{ with $caption }}<figcaption>{{ . | markdownify }}</figcaption>{{ end }}
-  </figure>
+    Steps:
+    1. Check the media queries in the `sizes` property.
+    2. Find the first matching value. For example, on a mobile device with a CSS pixel width
+    of 390px and DPR = 3 (iPhone 13), given setting sizes="(min-width: 768px) 50vw, 100vw",
+    it matches the `100vw` option.
+    3. Calculate the optimal image size: 390 × 3 × 100% (100vw) = 1170.
+    4. Find the corresponding match in the `srcset`.
 
-{{ else }}
-  {{ partial 
-    "img"
-    (dict
-      "src" $url.String
-      "class" $class
-      "alt" $altText
-      "caption" $caption
-      "page" $.Page
-      "watermark" $watermark)
-  }}
-{{ end }}
+    To make the browser select a smaller image on mobile devices
+    override the template and change the `sizes` property to "(min-width: 768px) 50vw, 30vw"
+
+    The sizes="auto" is valid only when loading="lazy".
+  */}}
+  {{- $imgObj := .imgObj -}}
+  {{- $alt := .alt -}}
+  {{- $watermark := .watermark -}}
+  {{- $originalWidth := $imgObj.Width -}}
+
+  {{- $img800 := $imgObj -}}
+  {{- $img1280 := $imgObj -}}
+  {{- if gt $originalWidth 800 -}}
+    {{- $img800 = $imgObj.Resize "800x" -}}
+  {{- end -}}
+  {{- if gt $originalWidth 1280 -}}
+    {{- $img1280 = $imgObj.Resize "1280x" -}}
+  {{- end -}}
+
+  {{- if $watermark -}}
+    {{- $img800 = partial "watermark" (dict "image" $img800 "onlyImage" true) -}}
+    {{- $img1280 = partial "watermark" (dict "image" $img1280 "onlyImage" true) -}}
+    {{- $imgObj = partial "watermark" (dict "image" $imgObj "onlyImage" true) -}}
+  {{- end -}}
+
+  {{- $srcset := printf "%s 800w, %s 1280w" $img800.RelPermalink $img1280.RelPermalink -}}
+
+
+  <img
+    class="my-0 rounded-md"
+    loading="lazy"
+    decoding="async"
+    fetchpriority="auto"
+    alt="{{ $alt }}"
+    {{ with $imgObj.Width }}width="{{ . }}"{{ end }}
+    {{ with $imgObj.Height }}height="{{ . }}"{{ end }}
+    src="{{ $img800.RelPermalink }}"
+    srcset="{{ $srcset }}"
+    sizes="(min-width: 768px) 50vw, 65vw"
+    data-zoom-src="{{ $imgObj.RelPermalink }}">
+{{- end -}}
+
+{{- define "RenderImageCaption" -}}
+  {{- with .caption -}}
+    <figcaption>{{ . | markdownify }}</figcaption>
+  {{- end -}}
+{{- end -}}
+
+{{- $disableImageOptimizationMD := .Page.Site.Params.disableImageOptimizationMD | default false -}}
+{{- $urlStr := .Destination | safeURL -}}
+{{- $url := urls.Parse $urlStr -}}
+{{- $altText := .Text -}}
+{{- $caption := .Title -}}
+{{- $isRemote := findRE "^(https?|data)" $url.Scheme -}}
+{{- $resource := "" -}}
+
+{{- $watermark := true -}}
+{{- if eq (substr $altText -5 5) "no-wm" -}}
+  {{- $altText = (trim (replace $altText "no-wm" "") " ") -}}
+  {{- $watermark = false -}}
+{{- end -}}
+
+{{- if not $isRemote -}}
+  {{- $resource = or ($.Page.Resources.GetMatch $urlStr) (resources.Get $urlStr) -}}
+{{- end -}}
+
+
+<figure
+  {{- range $k, $v := .Attributes -}}
+    {{- if $v -}}
+      {{- printf " %s=%q" $k ($v | transform.HTMLEscape) | safeHTMLAttr -}}
+    {{- end -}}
+  {{- end -}}>
+  {{- if $isRemote -}}
+    {{- $remoteImg := resources.GetRemote $urlStr -}}
+    {{- with $remoteImg -}}
+      {{- template "RenderImageSimple" (dict "imgObj" . "src" .RelPermalink "alt" $altText "watermark" $watermark) -}}
+    {{- else -}}
+      {{- template "RenderImageSimple" (dict "imgObj" "" "src" $urlStr "alt" $altText "watermark" false) -}}
+    {{- end -}}
+  {{- else if $resource -}}
+    {{- $isSVG := eq $resource.MediaType.SubType "svg" -}}
+    {{- $shouldOptimize := and (not $disableImageOptimizationMD) (not $isSVG) -}}
+    {{- if $shouldOptimize -}}
+      {{- template "RenderImageResponsive" (dict "imgObj" $resource "alt" $altText "watermark" $watermark) -}}
+    {{- else -}}
+      {{/* Not optimize image
+        If it is an SVG file, pass the permalink
+        Otherwise, pass the resource to allow width and height attributes
+      */}}
+      {{- if $isSVG -}}
+        {{- template "RenderImageSimple" (dict "imgObj" "" "src" $resource.RelPermalink "alt" $altText "watermark" false) -}}
+      {{- else -}}
+        {{- template "RenderImageSimple" (dict "imgObj" $resource "src" $resource.RelPermalink "alt" $altText "watermark" $watermark) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- template "RenderImageSimple" (dict "imgObj" "" "src" $urlStr "alt" $altText "watermark" false) -}}
+  {{- end -}}
+
+  {{- template "RenderImageCaption" (dict "caption" $caption) -}}
+</figure>

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -57,7 +57,8 @@
     {{- $imgObj = partial "watermark" (dict "image" $imgObj "onlyImage" true) -}}
   {{- end -}}
 
-  {{- /* Create responsive srcset from the watermarked image */ -}}
+  {{- /* Convert to WebP and create responsive variants */ -}}
+  {{- $imgObj = $imgObj.Process "webp" -}}
   {{- $img800 := $imgObj -}}
   {{- $img1280 := $imgObj -}}
   {{- if gt $originalWidth 800 -}}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -52,6 +52,12 @@
   {{- $watermark := .watermark -}}
   {{- $originalWidth := $imgObj.Width -}}
 
+  {{- /* Apply watermark if enabled */ -}}
+  {{- if $watermark -}}
+    {{- $imgObj = partial "watermark" (dict "image" $imgObj "onlyImage" true) -}}
+  {{- end -}}
+
+  {{- /* Create responsive srcset from the watermarked image */ -}}
   {{- $img800 := $imgObj -}}
   {{- $img1280 := $imgObj -}}
   {{- if gt $originalWidth 800 -}}
@@ -59,12 +65,6 @@
   {{- end -}}
   {{- if gt $originalWidth 1280 -}}
     {{- $img1280 = $imgObj.Resize "1280x" -}}
-  {{- end -}}
-
-  {{- if $watermark -}}
-    {{- $img800 = partial "watermark" (dict "image" $img800 "onlyImage" true) -}}
-    {{- $img1280 = partial "watermark" (dict "image" $img1280 "onlyImage" true) -}}
-    {{- $imgObj = partial "watermark" (dict "image" $imgObj "onlyImage" true) -}}
   {{- end -}}
 
   {{- $srcset := printf "%s 800w, %s 1280w" $img800.RelPermalink $img1280.RelPermalink -}}

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -1,95 +1,130 @@
-<!-- Modified version of Blowfish's layouts/partials/article-link/simple.html to support custom process_list_featured_img partial -->
+{{/*
+  Modified version of Blowfish v2.93.0's layouts/partials/article-link/simple.html to support custom watermarking.
+  Changed lines:
+    - 70-73: Apply watermark to local featured images before URL generation via process_list_featured_img partial
+*/}}
 
-{{ $constrainItemsWidth := .Page.Site.Params.list.constrainItemsWidth | default false }}
+{{/* Used by
+  1. list.html and term.html (when the cardView option is not enabled)
+  2. Recent articles template (when the cardView option is not enabled)
+  3. Shortcode list.html
+*/}}
 
-{{ $articleClasses := "flex flex-wrap article" }}
-{{ if .Site.Params.list.showCards }}
-{{ $articleClasses = delimit (slice $articleClasses "border border-neutral-200 dark:border-neutral-700 border-2 rounded-md overflow-hidden") " " }}
+{{ $constrainItemsWidth := site.Params.list.constrainItemsWidth | default false }}
+{{ $disableImageOptimization := site.Store.Get "disableImageOptimization" }}
+
+{{ $cardClasses := "flex flex-col md:flex-row relative" }}
+{{ $imgWrapperClasses := "" }}
+{{ $cardContentClasses := "" }}
+
+{{ if site.Params.list.showCards }}
+  {{ $cardClasses = printf "%s overflow-hidden rounded-md border-2 border-neutral-200 dark:border-neutral-700" $cardClasses }}
+  {{ $imgWrapperClasses = "" }}
+  {{ $cardContentClasses = printf "%s p-4" $cardContentClasses }}
 {{ else }}
-{{ $articleClasses = delimit (slice $articleClasses "") " " }}
-{{ end }}
-
-{{ $articleImageClasses := "w-full md:w-auto h-full thumbnail nozoom" }}
-{{ if .Site.Params.list.showCards }}
-{{ $articleImageClasses = delimit (slice $articleImageClasses "") " " }}
-{{ else }}
-{{ $articleImageClasses = delimit (slice $articleImageClasses "thumbnailshadow md:mr-7") " " }}
-{{ end }}
-
-{{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
-
-{{ $articleInnerClasses := "" }}
-{{ if .Site.Params.list.showCards }}
-{{ $articleInnerClasses = delimit (slice $articleInnerClasses "p-4") " " }}
-{{ else }}
-{{ $articleInnerClasses = delimit (slice $articleInnerClasses "mt-3 md:mt-0") " " }}
+  {{ $cardClasses = $cardClasses }}
+  {{ $imgWrapperClasses = printf "%s thumbnail-shadow md:mr-7" $imgWrapperClasses }}
+  {{ $cardContentClasses = printf "%s mt-3 md:mt-0" $cardContentClasses }}
 {{ end }}
 
 {{ if $constrainItemsWidth }}
-{{ $articleClasses = delimit (slice $articleClasses "max-w-prose") " " }}
+  {{ $cardClasses = printf "%s max-w-prose" $cardClasses }}
+{{ end }}
+
+{{ $page := .Page }}
+{{ $featured := "" }}
+{{ $featuredURL := "" }}
+{{ if not .Params.hideFeatureImage }}
+  {{/* frontmatter */}}
+  {{ with $page }}
+    {{ with .Params.featureimage }}
+      {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+        {{ if site.Params.hotlinkFeatureImage }}
+          {{ $featuredURL = . }}
+        {{ else }}
+          {{ $featured = resources.GetRemote . }}
+        {{ end }}
+      {{ else }}
+        {{ $featured = resources.Get . }}
+      {{ end }}
+    {{ end }}
+
+    {{/* page resources */}}
+    {{ if not (or $featured $featuredURL) }}
+      {{ $images := .Resources.ByType "image" }}
+      {{ range slice "*feature*" "*cover*" "*thumbnail*" }}
+        {{ if not $featured }}{{ $featured = $images.GetMatch . }}{{ end }}
+      {{ end }}
+    {{ end }}
+
+    {{/* fallback to default */}}
+    {{ if not (or $featured $featuredURL) }}
+      {{ $default := site.Store.Get "defaultFeaturedImage" }}
+      {{ if $default.url }}
+        {{ $featuredURL = $default.url }}
+      {{ else if $default.obj }}
+        {{ $featured = $default.obj }}
+      {{ end }}
+    {{ end }}
+
+    {{/* CUSTOM: Apply watermark to local resources before generating URL */}}
+    {{ if and $featured (not $featuredURL) }}
+      {{ $featured = partial "process_list_featured_img" (dict "image" $featured "onlyImage" true "page" $page "disableImageOptimization" $disableImageOptimization) }}
+    {{ end }}
+
+    {{/* generate image URL if not hotlink */}}
+    {{ if not $featuredURL }}
+      {{ with $featured }}
+        {{ $featuredURL = .RelPermalink }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
 {{ end }}
 
 
-{{ with .Params.externalUrl }}
-<a class="{{ $articleClasses }}" href="{{ . }}" target="_blank" rel="external">
-  {{ else }}
-  <a class="{{ $articleClasses }}" href="{{ .RelPermalink }}">
-    {{ end }}
-    {{- with $.Params.images -}}
-    {{- range first 6 . }}
-    <meta property="og:image" content="{{ . | absURL }}" />{{ end -}}
-    {{- else -}}
-    {{- $images := $.Resources.ByType "image" -}}
-    {{- $featured := $images.GetMatch "*feature*" -}}
-    {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
-    {{ if and .Params.featureimage (not $featured) }}
-    {{- $url:= .Params.featureimage -}}
-    {{ $featured = resources.GetRemote $url }}
-    {{ end }}
-    {{- if not $featured }}{{ with .Site.Params.defaultFeaturedImage }}{{ $featured = resources.Get . }}{{ end }}{{ end -}}
-    {{ if .Params.hideFeatureImage }}{{ $featured = false }}{{ end }}
-    <!-- Watermark and display featured image if it exists and watermark isn't disabled for article -->
-    {{- with $featured -}}
-    {{ partial "process_list_featured_img" (dict "image" . "class" $articleImageClasses "page" $.Page) }}
-    {{- with $.Site.Params.images }}
-    <meta property="og:image" content="{{ index . 0 | absURL }}" />{{ end -}}
-    {{- end -}}
-    {{- end -}}
-
-
-    <div class="{{ $articleInnerClasses }}">
-      <div class="items-center text-left text-xl font-semibold">
-        {{ with .Params.externalUrl }}
-        <div>
-          <div
-            class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral">
-            {{ $.Title | emojify }}
-            <span class="text-xs align-top cursor-default text-neutral-400 dark:text-neutral-500">
+<article class="{{ $cardClasses }}">
+  {{ with $featuredURL }}
+    <div class="flex-none relative overflow-hidden {{ $imgWrapperClasses }} thumbnail">
+      <img
+        src="{{ . }}"
+        alt="{{ $.Params.featuredImageAlt | default ($.Title | emojify) }}"
+        loading="lazy"
+        decoding="async"
+        class="not-prose absolute inset-0 w-full h-full object-cover">
+    </div>
+  {{ end }}
+  <div class="{{ $cardContentClasses }}">
+    <header class="items-center text-start text-xl font-semibold">
+      <a
+        {{ with $page.Params.externalUrl }}
+          href="{{ . }}" target="_blank" rel="external"
+        {{ else }}
+          href="{{ $page.RelPermalink }}"
+        {{ end }}
+        class="not-prose before:absolute before:inset-0 decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
+        <h2>
+          {{ .Title | emojify }}
+          {{ if .Params.externalUrl }}
+            <span class="cursor-default align-top text-xs text-neutral-400 dark:text-neutral-500">
               <span class="rtl:hidden">&#8599;</span>
               <span class="ltr:hidden">&#8598;</span>
             </span>
-          </div>
-        </div>
-        {{ else }}
-        <div class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral"
-          href="{{ .RelPermalink }}">{{ .Title | emojify }}</div>
-        {{ end }}
-        {{ if and .Draft .Site.Params.article.showDraftLabel }}
-        <div class=" ltr:ml-2 rtl:mr-2">
-          {{ partial "badge.html" (i18n "article.draft" | emojify) }}
-        </div>
-        {{ end }}
-        {{ if templates.Exists "partials/extend-article-link.html" }}
-        {{ partial "extend-article-link.html" . }}
-        {{ end }}
-      </div>
-      <div class="text-sm text-neutral-500 dark:text-neutral-400">
-        {{ partial "article-meta/basic.html" . }}
-      </div>
-      {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
-      <div class="py-1 max-w-fit prose dark:prose-invert">
-        {{ .Summary | plainify }}
-      </div>
+          {{ end }}
+        </h2>
+      </a>
+      {{ if and .Draft .Site.Params.article.showDraftLabel }}
+        <div class="ms-2">{{ partial "badge.html" (i18n "article.draft" | emojify) }}</div>
       {{ end }}
+      {{ if templates.Exists "partials/extend-article-link.html" }}
+        {{ partial "extend-article-link.html" . }}
+      {{ end }}
+    </header>
+    <div class="text-sm text-neutral-500 dark:text-neutral-400">
+      {{ partial "article-meta/basic.html" . }}
     </div>
-  </a>
+    {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
+      <div class="prose dark:prose-invert max-w-fit py-1">{{ .Summary | plainify }}</div>
+    {{ end }}
+  </div>
+  <div class="px-6 pt-4 pb-2"></div>
+</article>

--- a/layouts/partials/extend-head-uncached.html
+++ b/layouts/partials/extend-head-uncached.html
@@ -3,6 +3,16 @@
 <!-- Snippet borrowed from Blowfish's layouts/partials/vendor.html to support custom gallery_glob shortcode -->
 {{ if page.HasShortcode "gallery_glob" }}
     {{ $packeryLib := resources.Get "lib/packery/packery.pkgd.min.js" }}
+    {{ $galleryCSS := resources.Get "css/components/gallery.css" }}
+    <script defer src="{{ $packeryLib.RelPermalink }}" integrity="{{ $packeryLib.Data.Integrity }}"></script>
+    {{ $galleryCSS = $galleryCSS | resources.Fingerprint "sha512" }}
+    <link
+        type="text/css"
+        rel="stylesheet"
+        href="{{ $galleryCSS.RelPermalink }}"
+        integrity="{{ $galleryCSS.Data.Integrity }}">
+
+    {{ $packeryLib := resources.Get "lib/packery/packery.pkgd.min.js" }}
     <script defer src="{{ $packeryLib.RelPermalink }}" integrity="{{ $packeryLib.Data.Integrity }}"></script>
 
     {{ $jsShortcodeGallery := resources.Get "js/shortcodes/gallery.js" }}

--- a/layouts/partials/img.html
+++ b/layouts/partials/img.html
@@ -1,7 +1,7 @@
 <!--
   Partial for rendering an image.
   Passes through optional Hugo image optimisation and my custom watermark partial.
-  Took inspiration from Blowfish's layouts/_default/_markup/render-image.html
+  Originally based on Blowfish's render-image.html approach, but heavily modified since.
 -->
 
 {{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
@@ -26,20 +26,54 @@
   {{ $image = $image | images.Filter $filter }}
   {{ if and (not $gallery) $caption }}<figure>{{ end }}
 
-  {{ if or $disableImageOptimization (eq .MediaType.SubType "svg") }}
-    <img class="{{ $class }}" src="{{ $src }}"/>
+  {{ $isSVG := eq .MediaType.SubType "svg" }}
+  {{ if or $disableImageOptimization $isSVG }}
+    <img class="{{ $class }}" src="{{ $image.RelPermalink }}" {{ with $alt }}alt="{{ . }}"{{ end }} />
   {{ else }}
+    <!-- Apply watermark if enabled -->
     {{ if $watermark }}
       {{ $image = partial "watermark" (dict "image" $image "onlyImage" true "position" $watermarkPos) }}
     {{ end }}
 
-    <!-- Convert image to WebP -->
+    <!-- Convert to WebP for better compression -->
     {{ with $image.Process "webp" }}
+      <!-- Create responsive srcset -->
+      {{ $originalWidth := .Width }}
+      {{ $img800 := . }}
+      {{ $img1280 := . }}
+
+      {{ if gt $originalWidth 800 }}
+        {{ $img800 = .Resize "800x" }}
+      {{ end }}
+      {{ if gt $originalWidth 1280 }}
+        {{ $img1280 = .Resize "1280x" }}
+      {{ end }}
+
+      {{ $srcset := printf "%s 800w, %s 1280w" $img800.RelPermalink $img1280.RelPermalink }}
+
+      <!-- Extract grid width from class for smart sizes attribute -->
+      {{ $sizes := "(min-width: 768px) 50vw, 65vw" }}
+      {{ if $gallery }}
+        {{ $gridWidth := "33" }}
+        {{ if findRE `grid-w\d+` $class }}
+          {{ $matches := findRE `grid-w(\d+)` $class }}
+          {{ if $matches }}
+            {{ $gridWidth = replaceRE `grid-w(\d+)` "$1" (index $matches 0) }}
+          {{ end }}
+        {{ end }}
+        {{ $sizes = printf "%svw" $gridWidth }}
+      {{ end }}
+
       <img
         class="{{ $class }}"
-        {{ if not $gallery }}loading="lazy"{{ end }}
-        src="{{ .RelPermalink }}"
+        {{ if not $gallery }}loading="lazy" decoding="async" fetchpriority="auto"{{ end }}
         {{ with $alt }}alt="{{ . }}"{{ end }}
+        width="{{ .Width }}"
+        height="{{ .Height }}"
+        src="{{ $img800.RelPermalink }}"
+        srcset="{{ $srcset }}"
+        sizes="{{ $sizes }}"
+        data-zoom-src="{{ .RelPermalink }}"
       />
     {{ end }}
   {{ end }}

--- a/layouts/partials/img.html
+++ b/layouts/partials/img.html
@@ -79,7 +79,7 @@
   {{ end }}
 
   {{ if and (not $gallery) $caption }}
-    <figcaption>{{ $caption | markdownify }}</figcaption>
+    <figcaption>{{ $caption | safeHTML }}</figcaption>
     </figure>
   {{ end }}
 

--- a/layouts/partials/img.html
+++ b/layouts/partials/img.html
@@ -37,7 +37,7 @@
 
     <!-- Convert to WebP for better compression -->
     {{ with $image.Process "webp" }}
-      <!-- Create responsive srcset -->
+      <!-- Create responsive srcset from the watermarked image -->
       {{ $originalWidth := .Width }}
       {{ $img800 := . }}
       {{ $img1280 := . }}

--- a/layouts/partials/process_list_featured_img.html
+++ b/layouts/partials/process_list_featured_img.html
@@ -7,20 +7,27 @@
 {{ $image := .image }}
 {{ $class := .class }}
 {{ $page := .page }}
+{{ $onlyImage := default false .onlyImage }}
 
 {{ $logo := (resources.Get "watermark.png") }}
 {{ $watermarked := false }}
 
-<!-- Disable image optimisation per site params or if image is SVG -->
-{{ $disableImageOptimization := default false (
-    or
-      $page.Site.Params.disableImageOptimization 
-      (strings.HasSuffix $image ".svg"))
-}}
+{{ $should_wm := true }}
 
-<!-- Throw an error if either the image or logo is missing -->
-{{ if or (not $image) (not $logo) }}
-  {{ errorf "watermark_post: Image or logo missing. Context: %+v" . }}
+<!-- Get image optimisation setting from caller, fallback to site params or SVG check -->
+{{ $disableImageOptimization := false }}
+{{ if isset . "disableImageOptimization" }}
+  {{ $disableImageOptimization = .disableImageOptimization }}
+{{ else }}
+  {{ $isSVG := eq $image.MediaType.SubType "svg" }}
+  {{ $siteDisabled := $page.Site.Store.Get "disableImageOptimization" }}
+  {{ $disableImageOptimization = or $siteDisabled $isSVG }}
+{{ end }}
+
+<!-- Skip watermarking and warn if image or logo not found -->
+{{ if not (and $image $logo) }}
+  {{ warnf "process_list_featured_img: Image or logo missing. Context: %+v" . }}
+  {{ $should_wm = false }}
 {{ end }}
 
 
@@ -29,8 +36,15 @@
   {{ $image = $image.Resize "600x webp" }}
 {{ end }}
 
-<!-- Watermark image unless image name contains "watermark" or hideFeatureWatermark=true in page parameters  -->
-{{ if not (or (strings.Contains (strings.ToLower $image) "watermark") $page.Params.hideFeatureWatermark) }}
+<!-- Skip watermarking if image name contains "watermark" or hideFeatureWatermark=true in page parameters  -->
+{{ if strings.Contains (strings.ToLower $image.Name) "watermark" }}
+  {{ $should_wm = false }}
+{{ end }}
+{{ if $page.Params.hideFeatureWatermark }}
+  {{ $should_wm = false }}
+{{ end }}
+
+{{ if $should_wm }}
   <!-- Set watermark size to 25% of the image height, capped at 150px -->
   {{ $size := math.Round (mul $image.Height 0.25) }}
   {{ $size = cond (ge $size 150.0) ($size) 150.0 }}
@@ -67,4 +81,15 @@
 
 {{ end }}
 
-<div class="{{ $class }}" style="background-image:url({{ $image.RelPermalink }});" data-auto-watermarked="{{ $watermarked }}"></div>
+{{ if $onlyImage }}
+  {{ return $image }}
+{{ else }}
+  <img
+    src="{{ $image.RelPermalink }}"
+    alt="{{ $page.Params.featuredImageAlt | default ($page.Title | emojify) }}"
+    loading="lazy"
+    decoding="async"
+    class="{{ $class }}"
+    data-auto-watermarked="{{ $watermarked }}"
+  >
+{{ end }}

--- a/layouts/partials/watermark.html
+++ b/layouts/partials/watermark.html
@@ -16,7 +16,7 @@
 {{ end }}
 
 <!-- Skip watermarking if image name contains "watermark" -->
-{{ if strings.Contains (strings.ToLower $image) "watermark" }}
+{{ if strings.Contains (strings.ToLower $image.Name) "watermark" }}
   {{ $should_wm = false }}
 {{ end }}
 
@@ -40,7 +40,7 @@
 
   <!--
     Determine the vertical position of the logo.
-    Positions the logo slightly above the bottom of the cropped area, using a dynamic ratio to fix it ~5% above the bottom.
+    Positions the logo slightly above the bottom of the image, using a dynamic ratio to fix it ~5% above the bottom.
   -->
   {{ $y := div (sub $image.Height $logo.Height) 1.05 }}
 
@@ -53,5 +53,12 @@
 {{ if $onlyImage }}
   {{ return $image }}
 {{ else }}
-  <img alt="{{ $alt }}" src="{{ $image.RelPermalink }}" class="{{ $class }}" data-auto-watermarked="{{ $watermarked }}"/>
+  <img
+    src="{{ $image.RelPermalink }}"
+    alt="{{ $alt }}"
+    loading="lazy"
+    decoding="async"
+    class="{{ $class }}"
+    data-auto-watermarked="{{ $watermarked }}"
+  >
 {{ end }}

--- a/layouts/shortcodes/gallery_glob.html
+++ b/layouts/shortcodes/gallery_glob.html
@@ -1,7 +1,8 @@
 <!-- Mostly borrowed from hugo blowfish theme's gallery & carousel shortcodes -->
 
 <!-- Get site's image optimisation config -->
-{{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
+{{ $disableImageOptimization := .Page.Site.Store.Get "disableImageOptimization" | default false }}
+
 <!-- Generate random ID for the div element -->
 {{ $id := delimit (slice "gallery_glob" (partial "functions/uid.html" .)) "-" }}
 

--- a/scripts/diff_theme_overrides.sh
+++ b/scripts/diff_theme_overrides.sh
@@ -2,17 +2,44 @@
 
 modifiedfiles=(
   "layouts/partials/article-link/simple.html"
-  "layouts/partials/vendor.html"
   "layouts/_default/_markup/render-image.html"
 )
 
-repopath="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P | xargs dirname )"
-clonepath=$(mktemp -d)
+no_clean=false
 
-git clone git@github.com:nunocoracao/blowfish "$clonepath"
+# Parse arguments
+for arg in "$@"; do
+  case $arg in
+    --no-clean)
+      no_clean=true
+      shift
+      ;;
+    *)
+      # If a file is passed as an argument, use it instead of the default list
+      if [ -n "$arg" ]; then
+        modifiedfiles=("$arg")
+      fi
+      shift
+      ;;
+  esac
+done
+
+repopath="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P | xargs dirname )"
+
+# Check for existing clone
+existing_clone=$(find "$TMPDIR" -maxdepth 1 -type d -name "blowfish-theme-diff.*" 2>/dev/null | head -n 1)
+
+if [ -n "$existing_clone" ] && [ -d "$existing_clone/.git" ]; then
+  echo "Found existing clone at: $existing_clone"
+  clonepath="$existing_clone"
+else
+  clonepath=$(mktemp -d -t blowfish-theme-diff)
+  echo "Clone path: $clonepath"
+  git clone git@github.com:nunocoracao/blowfish "$clonepath" --depth 1
+fi
 
 cd "$clonepath"
-git checkout $(git describe --tags "$(git rev-list --tags --max-count=1)")
+git checkout $(git describe --tags "$(git rev-list --tags --max-count=1)") 2>/dev/null || echo "No tags found, using default branch"
 cd "$repopath"
 
 for file in ${modifiedfiles[@]}; do
@@ -20,4 +47,8 @@ for file in ${modifiedfiles[@]}; do
   git diff "${clonepath}/$file" "$file" || true
 done
 
-rm -rf "$clonepath"
+if [ "$no_clean" = false ]; then
+  rm -rf "$clonepath"
+else
+  echo -e "\nSkipping cleanup. Clone path preserved at: $clonepath"
+fi


### PR DESCRIPTION
Manually rebased my changes to the following Blowfish theme files on Blowfish v2.93.0:

-  layouts/_default/_markup/render-image.html
-  layouts/partials/article-link/simple.html

This was a horrible process and seems likely to cause problems, but changes to the theme have broken my modifications, so I was forced to rebase them.

Image optimisation is also vastly improved through the use of `srcset` attributes and better auto-resizing.